### PR TITLE
More maintainable versioning

### DIFF
--- a/python/companybook.py
+++ b/python/companybook.py
@@ -1,0 +1,1 @@
+API_ENDPOINT_BASE = 'https://openapi.companybooknetworking.com/1.2'

--- a/python/news.py
+++ b/python/news.py
@@ -1,4 +1,5 @@
 from authority import API_KEY
+from companybook import API_ENDPOINT_BASE
 from json import loads
 from logging import info, error
 from requests import get
@@ -11,7 +12,7 @@ HEADERS = {
 
 
 class NewsService:
-    COMPANY_RELATION_URL = "https://openapi.companybooknetworking.com/1.0/news/company-relation"
+    COMPANY_RELATION_URL = "{}/{}".format(API_ENDPOINT_BASE, 'news/company-relation')
 
     @classmethod
     def format_response(cls, raw_result, relation):

--- a/python/search.py
+++ b/python/search.py
@@ -1,4 +1,5 @@
 from authority import API_KEY
+from companybook import API_ENDPOINT_BASE
 from json import dumps, loads
 from logging import info, error
 from requests import get
@@ -11,8 +12,8 @@ HEADERS = {
 
 
 class SearchService:
-    MATCH = "https://openapi.companybooknetworking.com/1.0/search/match"
-    SEARCH = "https://openapi.companybooknetworking.com/1.0/search/search"
+    MATCH = "{}/{}".format(API_ENDPOINT_BASE, 'search/match')
+    SEARCH = "{}/{}".format(API_ENDPOINT_BASE, 'search/search')
     PARAMETERS = {
         'page': 1,
         'per_page': 10,

--- a/python/similar_companies.py
+++ b/python/similar_companies.py
@@ -1,4 +1,5 @@
 from authority import API_KEY
+from companybook import API_ENDPOINT_BASE
 from json import dumps, loads
 from logging import info, error
 from requests import get
@@ -11,7 +12,7 @@ HEADERS = {
 
 
 class SimilarCompaniesService:
-    COMPANY_URL = "https://openapi.companybooknetworking.com/1.0/similar-companies/company"
+    COMPANY_URL = "{}/{}".format(API_ENDPOINT_BASE, 'similar-companies/company')
 
     @classmethod
     def format_response(cls, raw_result):


### PR DESCRIPTION
Move base API url to a different file that is included by the
examples.
Bump API version to 1.2.